### PR TITLE
Fix UnimplementedError() by using double instead of int as fallback

### DIFF
--- a/lib/src/hoverover.dart
+++ b/lib/src/hoverover.dart
@@ -28,7 +28,7 @@ class _HoverOverState extends State<HoverOver> {
   Widget build(BuildContext context) {
     ///on hover translate the widget
     final hovered = Matrix4.identity()
-      ..translate(widget.translateXAxis ?? 0, widget.translateYAxis ?? 0);
+      ..translate(widget.translateXAxis ?? 0.0, widget.translateYAxis ?? 0.0);
     final transform = isHovered ? hovered : Matrix4.identity();
     return MouseRegion(
       onEnter: (_) => onEntered(true),

--- a/lib/src/hoverover.dart
+++ b/lib/src/hoverover.dart
@@ -31,6 +31,7 @@ class _HoverOverState extends State<HoverOver> {
       ..translate(widget.translateXAxis ?? 0.0, widget.translateYAxis ?? 0.0);
     final transform = isHovered ? hovered : Matrix4.identity();
     return MouseRegion(
+      cursor: SystemMouseCursors.click,
       onEnter: (_) => onEntered(true),
       onExit: (_) => onEntered(false),
 


### PR DESCRIPTION
This PR makes `translate` use double instead of int as fallback values. The reason being that when the fallback is used, the underlying function will throw an UnimplementedError(). This can happen when executing WidgetTests.

```

  void translate(dynamic x, [double y = 0.0, double z = 0.0]) {
    double tx;
    double ty;
    double tz;
    final tw = x is Vector4 ? x.w : 1.0;
    if (x is Vector3) {
      tx = x.x;
      ty = x.y;
      tz = x.z;
    } else if (x is Vector4) {
      tx = x.x;
      ty = x.y;
      tz = x.z;
    } else if (x is double) {
      tx = x;
      ty = y;
      tz = z;
    } else {
      throw UnimplementedError();
    }
```